### PR TITLE
[#57] Apply go fix

### DIFF
--- a/cloudevents-server/main_test.go
+++ b/cloudevents-server/main_test.go
@@ -17,15 +17,13 @@ func TestMain(t *testing.T) {
 	const configFile = "../common/config/config.yaml"
 
 	wg := new(sync.WaitGroup)
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 
 		os.Args = []string{"test", "-config-file=" + configFile}
 		flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 
 		main()
-	}()
+	})
 	time.Sleep(200 * time.Millisecond)
 
 	if err := config.Read(configFile); err != nil {
@@ -42,7 +40,7 @@ func TestMain(t *testing.T) {
 		sendEvent.SetType(eventType)
 		sendEvent.SetSource(eventSource)
 
-		for i := 0; i < 100; i++ {
+		for range 100 {
 			if receiveEvent, result := client.Request(sendEvent); result.IsUndelivered() {
 				t.Fatal(result.Error())
 			} else if statusCode, err := result.GetHttpStatusCode(); err != nil {

--- a/long-polling-server/main_test.go
+++ b/long-polling-server/main_test.go
@@ -93,7 +93,7 @@ func TestMain(t *testing.T) {
 		subscription(t, long_polling.SubscriptionRequest{Category: category, TimeoutSeconds: 300, SinceTime: timestamp, LastID: id}, 2, data)
 	}
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		wg.Add(1)
 		go clientJob("category-"+strconv.Itoa(i), "data-"+strconv.Itoa(i))
 	}


### PR DESCRIPTION
This pull request refactors test code in both `cloudevents-server/main_test.go` and `long-polling-server/main_test.go` to improve concurrency handling and simplify loop constructs. The most important changes are:

**Concurrency improvements:**

* Replaced manual `WaitGroup` management with the `Go` method for launching goroutines in `cloudevents-server/main_test.go`, making the test code more idiomatic and easier to maintain.

**Code simplification:**

* Changed `for i := 0; i < N; i++` to `for range N` in both `cloudevents-server/main_test.go` and `long-polling-server/main_test.go` to simplify loop syntax. [[1]](diffhunk://#diff-1f7de83f1a80a248e95ca1a0ff02d136f0d688171390addead688ea16c1a42afL45-R43) [[2]](diffhunk://#diff-3746c65b6e9c1906d485be3b8a6d1b7884caa04e4c860fd29e0814ea4699dc79L96-R96)